### PR TITLE
Feat: Add Support for official Django versions

### DIFF
--- a/demo_project/demo_project/settings.py
+++ b/demo_project/demo_project/settings.py
@@ -37,7 +37,6 @@ USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.
-USE_L10N = True
 
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
@@ -94,6 +93,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
+                'django.template.context_processors.request',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
@@ -102,7 +102,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -164,3 +164,5 @@ LOGGING = {
         },
     }
 }
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/demo_project/demo_project/settings.py
+++ b/demo_project/demo_project/settings.py
@@ -35,9 +35,6 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale.
-
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
 

--- a/demo_project/demo_project/urls.py
+++ b/demo_project/demo_project/urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from django.contrib import admin
 admin.autodiscover()
 
-
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
-    url(r'^grappelli/', include('grappelli.urls')),
+    path('admin/', include(admin.site.urls[:2])),
+    path('taggit_autosuggest/', include('taggit_autosuggest.urls')),
+    path('grappelli/', include('grappelli.urls')),
 ]

--- a/demo_project/posts/models.py
+++ b/demo_project/posts/models.py
@@ -15,7 +15,7 @@ class Post(models.Model):
 
 class Note(models.Model):
     text = models.TextField()
-    post = models.ForeignKey('Post')
+    post = models.ForeignKey('Post', on_delete=models.CASCADE)
     tags = TaggableManager(blank=True)
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = open('README.txt').read()
 
 setup(
     name='django-taggit-autosuggest',
-    version='0.4.1',
+    version='0.4.2',
     description='Autosuggestions for django-taggit',
     long_description=long_description,
     author='Fabian Topfstedt',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = open('README.txt').read()
 
 setup(
     name='django-taggit-autosuggest',
-    version='0.4.2',
+    version='0.4.1',
     description='Autosuggestions for django-taggit',
     long_description=long_description,
     author='Fabian Topfstedt',


### PR DESCRIPTION
This Repo is not a fork.
Original Repo https://bitbucket.org/fabian/django-taggit-autosuggest/src/master/

Tested with custom toe file
```
[tox]
skipsdist = true
args_are_paths = false
envlist =
    py38-{3.2,4.0,4.1,4.2}

[testenv]
usedevelop = true
basepython =
    py38: python3.8
deps =
    3.2: Django>=3.2,<3.3
    4.0: Django>=4.0,<4.1
    4.1: Django>=4.1,<4.2
    4.2: Django>=4.2,<4.3
setenv =
allowlist_externals =
    cd
commands =
    cd demo_project && {envpython} manage.py test

```


Output:

```
❯ tox
py38-3.2: install_deps> python -I -m pip install 'Django<3.3,>=3.2'
py38-3.2: commands[0]> cd demo_project '&&' /Users/irtazaakram/bom/django-taggit-autosuggest/.tox/py38-3.2/bin/python manage.py test
py38-3.2: OK ✔ in 11.84 seconds
py38-4.0: install_deps> python -I -m pip install 'Django<4.1,>=4.0'
py38-4.0: commands[0]> cd demo_project '&&' /Users/irtazaakram/bom/django-taggit-autosuggest/.tox/py38-4.0/bin/python manage.py test
py38-4.0: OK ✔ in 14.38 seconds
py38-4.1: install_deps> python -I -m pip install 'Django<4.2,>=4.1'
py38-4.1: commands[0]> cd demo_project '&&' /Users/irtazaakram/bom/django-taggit-autosuggest/.tox/py38-4.1/bin/python manage.py test
py38-4.1: OK ✔ in 20.69 seconds
py38-4.2: install_deps> python -I -m pip install 'Django<4.3,>=4.2'
py38-4.2: commands[0]> cd demo_project '&&' /Users/irtazaakram/bom/django-taggit-autosuggest/.tox/py38-4.2/bin/python manage.py test
  py38-3.2: OK (11.84=setup[11.81]+cmd[0.04] seconds)
  py38-4.0: OK (14.38=setup[14.33]+cmd[0.05] seconds)
  py38-4.1: OK (20.69=setup[20.62]+cmd[0.07] seconds)
  py38-4.2: OK (26.56=setup[26.49]+cmd[0.07] seconds)
  congratulations :) (73.75 seconds)
```